### PR TITLE
Eliminate GCC error for redefining VERSION

### DIFF
--- a/src/tlock.h
+++ b/src/tlock.h
@@ -60,10 +60,16 @@
 
 /* ----------------------------------------------------------------  *
  * PAM AUTHENTICATION DEFINITIONS
- /* ----------------------------------------------------------------  */
+ * ----------------------------------------------------------------  */
+#ifndef PAM_SERVICE_NAME
 #define PAM_SERVICE_NAME "system-auth"
+#endif
+#ifndef VERSION
 #define VERSION "1.0"
+#endif
+#ifndef STRING_LIMIT
 #define STRING_LIMIT 64
+#endif
 
 struct aXInfo {
 	Display* display;

--- a/src/tlock_cli.h
+++ b/src/tlock_cli.h
@@ -27,8 +27,12 @@
 /* ----------------------------------------------------------------  *
  * PAM AUTHENTICATION DEFINITIONS
 /* ----------------------------------------------------------------  */
+#ifndef PAM_SERVICE_NAME
 #define PAM_SERVICE_NAME "unix"
+#endif
+#ifndef VERSION
 #define VERSION "1.0"
+#endif
 
 struct aAuth {
 	const char* name;


### PR DESCRIPTION
Removes the GCC report about VERSION being redefined, fixes a comment warning, and masks PAM_SERVICE_NAME when necessary.